### PR TITLE
Fix favicon 404 warning

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/58HAAMBAF1NZEEAAAAASUVORK5CYII=" />
   <title>Math Path</title>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- add an inline favicon so browsers do not request a missing `favicon.ico`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_b_686dd784427083229e8635458cd00f59